### PR TITLE
Add React frontend and Apps Script backend example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Inventory_Garrage_2
+
+Simple example of an inventory app with a React front end and a Google Apps Script backend using a Google Sheet as storage.
+
+## Setup
+
+1. **Backend**
+   - Copy `backend/Code.gs` into the Apps Script editor of your Google Sheet.
+   - Deploy as a web app and copy the web app URL.
+
+2. **Frontend**
+   - Open `frontend/index.html` and replace `REPLACE_WITH_WEB_APP_URL` with the URL from the deployment step.
+   - Serve the file with any static host or open it directly in a browser.
+
+This demonstrates using Google Sheets as a lightweight database for an inventory list.

--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -1,0 +1,22 @@
+const SHEET_ID = '1n0C233s5m4cH5sjEJsbDTN6qfj0-yM5x2i8qBVvuxo8';
+const SHEET_NAME = 'Sheet1';
+
+function getSheet() {
+  return SpreadsheetApp.openById(SHEET_ID).getSheetByName(SHEET_NAME);
+}
+
+function doGet() {
+  const sheet = getSheet();
+  const data = sheet.getDataRange().getValues();
+  return ContentService.createTextOutput(JSON.stringify(data))
+                       .setMimeType(ContentService.MimeType.JSON);
+}
+
+function doPost(e) {
+  const body = JSON.parse(e.postData.contents);
+  const values = body.values;
+  getSheet().appendRow(values);
+  return ContentService.createTextOutput(
+    JSON.stringify({ status: 'OK' })
+  ).setMimeType(ContentService.MimeType.JSON);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Inventory</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      const WEB_APP_URL = 'REPLACE_WITH_WEB_APP_URL';
+
+      function App() {
+        const [items, setItems] = React.useState([]);
+        const [name, setName] = React.useState('');
+        const [qty, setQty] = React.useState('');
+
+        React.useEffect(() => {
+          fetch(WEB_APP_URL)
+            .then(res => res.json())
+            .then(setItems);
+        }, []);
+
+        function addItem(e) {
+          e.preventDefault();
+          fetch(WEB_APP_URL, {
+            method: 'POST',
+            body: JSON.stringify({ values: [name, qty] }),
+            headers: { 'Content-Type': 'application/json' }
+          }).then(() => {
+            setItems([...items, [name, qty]]);
+            setName('');
+            setQty('');
+          });
+        }
+
+        return (
+          <div>
+            <h1>Inventory</h1>
+            <ul>
+              {items.slice(1).map((row, i) => (
+                <li key={i}>{row[0]} ({row[1]})</li>
+              ))}
+            </ul>
+            <form onSubmit={addItem}>
+              <input value={name} onChange={e => setName(e.target.value)} placeholder="Item" />
+              <input value={qty} onChange={e => setQty(e.target.value)} placeholder="Qty" />
+              <button type="submit">Add</button>
+            </form>
+          </div>
+        );
+      }
+
+      ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Google Apps Script backend for Google Sheets inventory
- add React-based frontend page that fetches from Apps Script
- document setup steps for backend and frontend

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894afdf9e048329910965f9cb522fd7